### PR TITLE
Updating synchronous dynamics

### DIFF
--- a/epydemic/synchronousdynamics.py
+++ b/epydemic/synchronousdynamics.py
@@ -61,7 +61,7 @@ class SynchronousDynamics(Dynamics):
             nev = self.runPendingEvents(t)
             
             # run through all the events in the distribution
-            dist = proc.perElementEventDistribution(t)
+            dist = proc.dynamics().perElementEventDistribution(proc)
             for (l, p, ef) in dist:
                 if (len(l) > 0) and (p > 0.0):
                     # run through every possible element on which this event may occur
@@ -73,7 +73,7 @@ class SynchronousDynamics(Dynamics):
                             nev = nev + 1
 
             # run through all the fixed-rate events for this timestep
-            dist = proc.fixedRateEventDistribution(t)
+            dist = proc.dynamics().fixedRateEventDistribution(proc)
             for (l, p, ef) in dist:
                 if (len(l) > 0) and (p > 0.0):
                     if rng.random() <= p:


### PR DESCRIPTION
A friend currently taking the GD5302 was having some trouble getting some examples using SynchronousDynamics to work from the book and asked if I could take a look. I've tried to update synchronous dynamics to match the implementation given in the Epidemic Modelling book and it seems to work successfully on my machine (but will need to wait for continuous integration tests to prove that). 
I've updated the calls for `perElementEventDistribution` and `fixedRateEventDistribution` to be called against the dynamics of a process instead of the process directly and to pass them the process used to determine the events instead of the current time step. This seems to resolve the attribute errors currently occurring in unit tests and begins to produce successful results for simple models. 83/83 unit tests pass.
While I don't fully understand everything about how this library works, it seems like a fascinating project and look forward to seeing the future developments on it.